### PR TITLE
Ensure `checked` output is nonsensitive

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Generate Matrix
         id: matrix
-        uses: Invicton-Labs/terraform-module-testing/matrix@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/matrix@v0.4.0
         with:
           minimum_tf_version: '1.10.3'
           additional_runners: 'macos-13, windows-2019'
@@ -29,196 +29,196 @@ jobs:
     steps:
       - name: Initialize - Pass
         id: init-pass
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/pass
       - name: Run Tests - Pass
         id: tests-pass
-        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.4.0
         with:
           tf_path: tests/pass
           
       - name: Initialize - Pass (With Output)
         id: init-pass-output
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/pass-output
       - name: Run Tests - Pass (With Output)
         id: tests-pass-output
-        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.4.0
         with:
           tf_path: tests/pass-output
           
       - name: Initialize - Pass - Condition Delayed
         id: init-pass-condition-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/pass-condition-delayed
       - name: Run Tests - Pass - Condition Delayed
         id: tests-pass-condition-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.4.0
         with:
           tf_path: tests/pass-condition-delayed
           
       - name: Initialize - Pass - Message Delayed
         id: init-pass-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/pass-message-delayed
       - name: Run Tests - Pass - Message Delayed
         id: tests-pass-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.4.0
         with:
           tf_path: tests/pass-message-delayed
           stderr_contains: Unsuitable value for error message
           
       - name: Initialize - Pass - Condition & Message Delayed
         id: init-pass-condition-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/pass-condition-message-delayed
       - name: Run Tests - Pass - Condition & Message Delayed
         id: tests-pass-condition-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.4.0
         with:
           tf_path: tests/pass-condition-message-delayed
        
       - name: Initialize - Pass - Multi
         id: init-pass-multi
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/pass-multi
       - name: Run Tests - Pass - Multi
         id: tests-pass-multi
-        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.4.0
         with:
           tf_path: tests/pass-multi
        
       - name: Initialize - Pass - Multi - Condition Delayed
         id: init-pass-multi-condition-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/pass-multi-condition-delayed
       - name: Run Tests - Pass - Multi - Condition Delayed
         id: tests-pass-multi-condition-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.4.0
         with:
           tf_path: tests/pass-multi-condition-delayed
 
       - name: Initialize - Pass - Multi - Message Delayed
         id: init-pass-multi-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/pass-multi-message-delayed
       - name: Run Tests - Pass - Multi - Message Delayed
         id: tests-pass-multi-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.4.0
         with:
           tf_path: tests/pass-multi-message-delayed
           
       - name: Initialize - Pass - Multi - Condition and Message Delayed
         id: init-pass-multi-condition-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/pass-multi-condition-message-delayed
       - name: Run Tests - Pass - Multi - Condition and Message Delayed
         id: tests-pass-multi-condition-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-destroy@v0.4.0
         with:
           tf_path: tests/pass-multi-condition-message-delayed
           
       - name: Initialize - Fail
         id: init-fail
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/fail
       - name: Run Tests - Fail
         id: tests-fail
-        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.4.0
         with:
           tf_path: tests/fail
           stderr_contains: sample error
           
       - name: Initialize - Fail (Output)
         id: init-fail-output
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/fail-output
       - name: Run Tests - Fail (Output)
         id: tests-fail-output
-        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.4.0
         with:
           tf_path: tests/fail-output
           stderr_contains: sample error
           
       - name: Initialize - Fail - Condition Delayed
         id: init-fail-condition-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/fail-condition-delayed
       - name: Run Tests - Fail - Condition Delayed
         id: tests-fail-condition-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.4.0
         with:
           tf_path: tests/fail-condition-delayed
           stderr_contains: sample error
           
       - name: Initialize - Fail - Message Delayed
         id: init-fail-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/fail-message-delayed
       - name: Run Tests - Fail - Message Delayed
         id: tests-fail-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.4.0
         with:
           tf_path: tests/fail-message-delayed
           stderr_contains: Unsuitable value for error message
           
       - name: Initialize - Fail - Condition & Message Delayed
         id: init-fail-condition-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/fail-condition-message-delayed
       - name: Run Tests - Fail - Condition & Message Delayed
         id: tests-fail-condition-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.4.0
         with:
           tf_path: tests/fail-condition-message-delayed
           stderr_contains: sample error
           
       - name: Initialize - Fail - Multi - Condition Delayed
         id: init-fail-multi-condition-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/fail-multi-condition-delayed
       - name: Run Tests - Fail - Multi - Condition Delayed
         id: tests-fail-multi-condition-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.4.0
         with:
           tf_path: tests/fail-multi-condition-delayed
           stderr_contains: sample error
           
       - name: Initialize - Fail - Multi - Message Delayed
         id: init-fail-multi-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/fail-multi-message-delayed
       - name: Run Tests - Fail - Multi - Message Delayed
         id: tests-fail-multi-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.4.0
         with:
           tf_path: tests/fail-multi-message-delayed
           stderr_contains: Unsuitable value for error message
 
       - name: Initialize - Fail - Multi - Condition and Message Delayed
         id: init-fail-multi-condition-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/initialize@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/initialize@v0.4.0
         with:
           tf_path: tests/fail-multi-condition-message-delayed
       - name: Run Tests - Fail - Multi - Condition and Message Delayed
         id: tests-fail-multi-condition-message-delayed
-        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.3.0
+        uses: Invicton-Labs/terraform-module-testing/apply-failure@v0.4.0
         with:
           tf_path: tests/fail-multi-condition-message-delayed
           stderr_contains: sample error

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,12 +3,12 @@
 //==================================================
 output "error_message" {
   description = "The value of the `error_message` input variable."
-  value       = var.error_message
+  value       = nonsensitive(var.error_message)
 }
 
 output "condition" {
   description = "The value of the `condition` input variable."
-  value       = var.condition
+  value       = nonsensitive(var.condition)
 }
 
 output "assertions" {
@@ -21,5 +21,5 @@ output "assertions" {
 //==================================================
 output "checked" {
   description = "Whether the condition has been checked (used for assertion dependencies)."
-  value       = var.condition == true ? true : true
+  value       = nonsensitive(nonsensitive(var.condition) == true ? true : true)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,12 +3,12 @@
 //==================================================
 output "error_message" {
   description = "The value of the `error_message` input variable."
-  value       = nonsensitive(var.error_message)
+  value       = var.error_message
 }
 
 output "condition" {
   description = "The value of the `condition` input variable."
-  value       = nonsensitive(var.condition)
+  value       = var.condition
 }
 
 output "assertions" {


### PR DESCRIPTION
Currently, if the input variables are sensitive, the `checked` output variable will be sensitive. This doesn't make any sense, so this should address the issue.