### PR TITLE
Add opentofu version requirement

### DIFF
--- a/versions.tofu
+++ b/versions.tofu
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.9.0"
+}


### PR DESCRIPTION
This adds a versions.tofu file that overrides the versions.tf when used with OpenTofu.

The reason for this is the versioning of OpenTofu is very different to that of the versions of Terraform so the version spec has to be different for use with OpenTofu.